### PR TITLE
Remove invalid rules_cc archive link

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,7 +43,6 @@ http_archive(
 http_archive(
     name = "rules_cc",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/7e650b11fe6d49f70f2ca7a1c4cb8bcc4a1fe239.zip",
         "https://github.com/bazelbuild/rules_cc/archive/7e650b11fe6d49f70f2ca7a1c4cb8bcc4a1fe239.zip",
     ],
     strip_prefix = "rules_cc-7e650b11fe6d49f70f2ca7a1c4cb8bcc4a1fe239",


### PR DESCRIPTION
This pull request removes an invalid cc_rules archive link that generates a Bazel diagnostic warning during the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/tcmalloc/8)
<!-- Reviewable:end -->
