### PR TITLE
Added a gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Bazel
+bazel-*


### PR DESCRIPTION
This pull request adds a `.gitignore` file to prevent accidental check-in of Bazel created directories and files.