### PR TITLE
Add Safe-Linking to Single-Linked-Lists (SLL)

### DIFF
--- a/tcmalloc/internal/linked_list.h
+++ b/tcmalloc/internal/linked_list.h
@@ -25,14 +25,34 @@
 #include "absl/base/optimization.h"
 #include "tcmalloc/internal/logging.h"
 
+#ifdef TCMALLOC_USE_SLL_SAFE_LINKING
+// Safe-Linking:
+// Use randomness from ASLR (mmap_base) to protect the single-linked
+// lists used by the heap. Together with allocation alignment checks,
+// this mechanism reduces the risk of pointer hijacking, similarly to
+// the Safe-Unlinking in the double-linked lists of dlmalloc / ptmalloc.
+#define PROTECT_PTR(pos, ptr)     reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(pos) >> kPageShift) ^ reinterpret_cast<uintptr_t>(ptr))
+#define REVEAL_PTR(pos, ptr)      PROTECT_PTR(pos, ptr)
+#endif
+
 namespace tcmalloc {
 
 inline ABSL_ATTRIBUTE_ALWAYS_INLINE void *SLL_Next(void *t) {
+#ifdef TCMALLOC_USE_SLL_SAFE_LINKING
+  void * result = REVEAL_PTR(t, *(reinterpret_cast<void**>(t)));
+  CHECK_CONDITION((reinterpret_cast<uintptr_t>(result) % kAlignment) == 0);
+  return result;
+#else
   return *(reinterpret_cast<void**>(t));
+#endif
 }
 
 inline void ABSL_ATTRIBUTE_ALWAYS_INLINE SLL_SetNext(void *t, void *n) {
+#ifdef TCMALLOC_USE_SLL_SAFE_LINKING
+  *(reinterpret_cast<void**>(t)) = PROTECT_PTR(t, n);
+#else
   *(reinterpret_cast<void**>(t)) = n;
+#endif
 }
 
 inline void ABSL_ATTRIBUTE_ALWAYS_INLINE SLL_Push(void **list, void *element) {


### PR DESCRIPTION
Safe-Linking is a security mechanism that protects single-linked
lists (such as the Free Lists) from being tampered by attackers. The
mechanism makes use of the randomness from ASLR (mmap_base), and when
combined with object alignment integrity checks, it protects the
pointers from being hijacked by an attacker.

While Safe-Unlinking protects double-linked lists (such as the Small
Bins in ptmalloc), there wasn't any siilar protection for attacks
against single-linked lists. This solution protects against three
common attacks:
  * Partial pointer override: Modifies the lower bytes (Little Endian)
  * Full pointer override: Hijacks the pointer to an attacker's location
  * Unaligned objects: Pointing the list to an unaligned address

The design assumes an attacker doesn't know where the heap is located,
and uses the ASLR randomness to "sign" the single-linked pointers. We
mark the pointer as P and the location in which it is stored as L, and
the calculation will be:
  * PROTECT(P) := (L >> PAGE_SHIFT) XOR (P)
  * *L = PROTECT(P)

This way, the random bits from the address L (which start at the bits
in the PAGE_SHIFT position), will be merged with the LSB of the stored
protected pointer. This protection layer prevents an attacker from
modifying the pointer into a controlled value.

An additionl check that the objects are kAligned adds an important
layer:
  * Attackers can't point to illegal (unaligned) memory address
  * Attackers must guess correctly the alignment bits

Due to kAlignment being 8, an attacker will directly fail 7 out of 8
times. And this could be improved in the future if the alignment will
match the class size, per Free List.

This proposed patch was benchmarked using gperftools's benchmarking suite
and on the worst test case it has an additional overhead of 1.5%, while the
overhead for the average test case was a negligible 0.02%. In addition, in
2013 a similar mitigation was incorporated into Chromium's Free List (FL)
implementation in their version of TCMalloc. According to Chromium's
documentation, the added overhead was less than 2%.

Safe-Linking will currently be activated if compiled using the MACRO:
```TCMALLOC_USE_SLL_SAFE_LINKING```.
Hopefully, this feature will be activated by default after further testings
by the repository's developers.

A similar pull request was also sent to GLIBC (ptmalloc), uClibg-NG (dlmalloc),
and gperftools's implementation of TCMalloc.

For more information, feel free to read our full white-paper (attached):
[Safe-Linking-White-Paper.txt](https://github.com/google/tcmalloc/files/4250712/Safe-Linking-White-Paper.txt)
