### PR TITLE
Fix code model check for aarch64

### DIFF
--- a/tcmalloc/internal/percpu_rseq_aarch64.S
+++ b/tcmalloc/internal/percpu_rseq_aarch64.S
@@ -121,7 +121,7 @@ label##_trampoline:                                               \
  */
 #define ENCODE_SIZE(label) .size label, . - label
 /* We are assuming small memory model.  */
-#if __clang_major__ >= 9 && !defined(__AARCH64_CMODEL_SMALL__)
+#if __clang_major__ >= 11 && !defined(__AARCH64_CMODEL_SMALL__)
 #error "Memory model not supported!"
 #endif
 


### PR DESCRIPTION
__AARCH64_CMODEL_SMALL__ macro was introduced in clang 11.0.0, not 9.0.0.