### PR TITLE
Fix visibility for //tcmalloc:llvm

### DIFF
--- a/tcmalloc/BUILD
+++ b/tcmalloc/BUILD
@@ -32,7 +32,10 @@ config_setting(
     flag_values = {
         "@bazel_tools//tools/cpp:compiler": "clang",
     },
-    visibility = ["//visibility:private"],
+    visibility = [
+        "//tcmalloc/internal:__subpackages__",
+        "//tcmalloc/testing:__subpackages__",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
Due to bazelbuild/bazel@cac82cf, future Bazel version will enforce
visibility check on keys of select(). This PR fixes visibilty of
//tcmalloc:llvm so that projects depending on tcmalloc can still be able
to build with Bazel@HEAD.

Related: https://github.com/bazelbuild/bazel/issues/12925