### PR TITLE
Remove dead code

### DIFF
--- a/tcmalloc/tcmalloc.cc
+++ b/tcmalloc/tcmalloc.cc
@@ -2210,14 +2210,7 @@ extern "C" void* TCMallocInternalNewArray(size_t size)
     TCMALLOC_ALIAS(TCMallocInternalNew);
 #else
 {
-  void* p = fast_alloc(CppPolicy().WithoutHooks(), size);
-  // We keep this next instruction out of fast_alloc for a reason: when
-  // it's in, and new just calls fast_alloc, the optimizer may fold the
-  // new call into fast_alloc, which messes up our whole section-based
-  // stacktracing (see ABSL_ATTRIBUTE_SECTION, above).  This ensures fast_alloc
-  // isn't the last thing this fn calls, and prevents the folding.
-  MallocHook::InvokeNewHook(p, size);
-  return p;
+  return fast_alloc(CppPolicy().WithoutHooks(), size);
 }
 #endif  // TCMALLOC_ALIAS
 


### PR DESCRIPTION
Seems that this code is never actually compiled, since TCMALLOC_ALIAS is always defined.

This line mentions `MallocHook::InvokeNewHook`, put there are no other mentions of `MallocHook` in the repository since initial commit.

As far as I can tell, `MallocHook` was initially present in gperftools, but later was removed from tcmalloc.

https://github.com/gperftools/gperftools/blob/f7c6fb6c8e99d6b1b725e5994373bcd19ffdf8fd/src/gperftools/malloc_hook.h#L98