### PR TITLE
suppress C++20 deprecated-volatile warning from new LLVM toolchains

### DIFF
--- a/tcmalloc/copts.bzl
+++ b/tcmalloc/copts.bzl
@@ -19,6 +19,7 @@ TCMALLOC_LLVM_FLAGS = [
     # aren't necessarily -Werror clean.
     "-Werror",
     "-Wno-deprecated-declarations",
+    "-Wno-deprecated-volatile",
     "-Wno-implicit-int-float-conversion",
     "-Wno-sign-compare",
     "-Wno-uninitialized",

--- a/tcmalloc/sampler.h
+++ b/tcmalloc/sampler.h
@@ -233,7 +233,10 @@ Sampler::TryRecordAllocationFast(size_t k) {
     // register. This helps compiler generate slightly more efficient
     // sub <reg>, <mem> instruction for subtraction above.
     volatile ssize_t* ptr = const_cast<volatile ssize_t*>(&bytes_until_sample_);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-volatile"
     *ptr += k;
+#pragma clang diagnostic pop
     return false;
   }
   return true;

--- a/tcmalloc/sampler.h
+++ b/tcmalloc/sampler.h
@@ -233,10 +233,7 @@ Sampler::TryRecordAllocationFast(size_t k) {
     // register. This helps compiler generate slightly more efficient
     // sub <reg>, <mem> instruction for subtraction above.
     volatile ssize_t* ptr = const_cast<volatile ssize_t*>(&bytes_until_sample_);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-volatile"
     *ptr += k;
-#pragma clang diagnostic pop
     return false;
   }
   return true;


### PR DESCRIPTION
Fixes #106 