### PR TITLE
define CPUCache as a class, not a struct

### DIFF
--- a/tcmalloc/cpu_cache.h
+++ b/tcmalloc/cpu_cache.h
@@ -1565,7 +1565,7 @@ inline uint32_t CPUCache<Forwarder>::PerClassResizeInfo::Tick() {
 
 // Static forward declares CPUCache to avoid a cycle in headers.  Make
 // "CPUCache" be non-templated to avoid breaking that forward declaration.
-struct CPUCache final
+class CPUCache final
     : public cpu_cache_internal::CPUCache<cpu_cache_internal::StaticForwarder> {
 };
 


### PR DESCRIPTION
Fixes the compilation error below:
```
In file included from external/com_google_tcmalloc/tcmalloc/static_vars.cc:26:
external/com_google_tcmalloc/tcmalloc/cpu_cache.h:1568:1: error: 'CPUCache' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
struct CPUCache final
^
external/com_google_tcmalloc/tcmalloc/static_vars.h:49:1: note: did you mean struct here?
class CPUCache;
^~~~~
struct
1 error generated.
```
Previously `CPUCache` was defined as a class, so this was almost definitely an unintended change.