### PR TITLE
stop using deprecated ATOMIC_VAR_INIT macro

### DIFF
--- a/tcmalloc/system-alloc.cc
+++ b/tcmalloc/system-alloc.cc
@@ -372,7 +372,7 @@ void BindMemory(void* const base, const size_t size, const size_t partition) {
         nodemask);
 }
 
-ABSL_CONST_INIT std::atomic<int> system_release_errors = ATOMIC_VAR_INIT(0);
+ABSL_CONST_INIT std::atomic<int> system_release_errors(0);
 
 }  // namespace
 


### PR DESCRIPTION
`ATOMIC_VAR_INIT` is deprecated in C++20; seemingly, since its introduction it seems to merely call the constructor of `std::atomic<T>`. It only exists for compatibility with C, which hasn't needed its equivalent since C11 and also deprecated it in C17.