### PR TITLE
place no-destroy attribute before non-attributes

### DIFF
--- a/tcmalloc/static_vars.cc
+++ b/tcmalloc/static_vars.cc
@@ -46,7 +46,7 @@ ABSL_CONST_INIT absl::base_internal::SpinLock pageheap_lock(
     absl::kConstInit, absl::base_internal::SCHEDULE_KERNEL_ONLY);
 ABSL_CONST_INIT Arena Static::arena_;
 ABSL_CONST_INIT SizeMap ABSL_CACHELINE_ALIGNED Static::sizemap_;
-ABSL_CONST_INIT TCMALLOC_ATTRIBUTE_NO_DESTROY TransferCacheManager
+TCMALLOC_ATTRIBUTE_NO_DESTROY ABSL_CONST_INIT TransferCacheManager
     Static::transfer_cache_;
 ABSL_CONST_INIT ShardedTransferCacheManager
     Static::sharded_transfer_cache_(nullptr, nullptr);

--- a/tcmalloc/static_vars.h
+++ b/tcmalloc/static_vars.h
@@ -180,7 +180,7 @@ class Static {
 
   ABSL_CONST_INIT static Arena arena_;
   static SizeMap sizemap_;
-  ABSL_CONST_INIT TCMALLOC_ATTRIBUTE_NO_DESTROY static TransferCacheManager
+  TCMALLOC_ATTRIBUTE_NO_DESTROY ABSL_CONST_INIT static TransferCacheManager
       transfer_cache_;
   ABSL_CONST_INIT static ShardedTransferCacheManager sharded_transfer_cache_;
   static CpuCache cpu_cache_;


### PR DESCRIPTION
This fixes a compilation failure in C++20 onwards.

In b6a1b575a14522e530387be6f30a50342c6d8825, the `[[clang::no_destroy]]` attribute was added to the library, but applied in an incorrect place in the syntax. When compiled with clang 15, compilation succeeds in c++17 mode but fails in c++20 mode with the following errors:

```
In file included from external/com_google_tcmalloc/tcmalloc/sampler.h:26:
external/com_google_tcmalloc/tcmalloc/static_vars.h:183:19: error: an attribute list cannot appear here
  ABSL_CONST_INIT TCMALLOC_ATTRIBUTE_NO_DESTROY static TransferCacheManager
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
external/com_google_tcmalloc/tcmalloc/internal/config.h:72:39: note: expanded from macro 'TCMALLOC_ATTRIBUTE_NO_DESTROY'
#define TCMALLOC_ATTRIBUTE_NO_DESTROY [[clang::no_destroy]]
                                      ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
```
external/com_google_tcmalloc/tcmalloc/static_vars.cc:49:17: error: 'no_destroy' attribute cannot be applied to types
ABSL_CONST_INIT TCMALLOC_ATTRIBUTE_NO_DESTROY TransferCacheManager
                ^
external/com_google_tcmalloc/tcmalloc/internal/config.h:72:41: note: expanded from macro 'TCMALLOC_ATTRIBUTE_NO_DESTROY'
#define TCMALLOC_ATTRIBUTE_NO_DESTROY [[clang::no_destroy]]
                                        ^
1 error generated.
```

This is because after C++17, `TCMALLOC_CONSTINIT` is defined to the `constinit` keyword instead of an attribute, so this ends up placing the no-destroy attribute in the middle of the declaration instead of among the preceding attributes. To fix this error, the no-destroy attribute should be moved.