### PR TITLE
Only use inline asm for rseq on supported compilers

### DIFF
--- a/tcmalloc/internal/percpu.h
+++ b/tcmalloc/internal/percpu.h
@@ -18,8 +18,12 @@
 #define TCMALLOC_PERCPU_SLABS_MASK 0xFFFFFFFFFFFFFF00
 
 // TCMALLOC_PERCPU_RSEQ_SUPPORTED_PLATFORM defines whether or not we have an
-// implementation for the target OS and architecture.
-#if defined(__linux__) && (defined(__x86_64__) || defined(__aarch64__))
+// implementation for the target OS and architecture on a supported compiler.
+// Build on aarch64 fails on gcc-9, gcc-10, and clang-10, but succeeds on
+// gcc-11, clang-11, and clang-14, so require at least clang 11 or gcc 11 for
+// aarch64.
+#if defined(__linux__) && (defined(__x86_64__) || \
+			   (defined(__aarch64__) && (__clang_major__ >= 11 || __GNUC__ >= 11)))
 #define TCMALLOC_PERCPU_RSEQ_SUPPORTED_PLATFORM 1
 #else
 #define TCMALLOC_PERCPU_RSEQ_SUPPORTED_PLATFORM 0
@@ -58,7 +62,7 @@
 
 // TCMALLOC_INTERNAL_PERCPU_USE_RSEQ defines whether TCMalloc support for RSEQ
 // on the target architecture exists. We currently only provide RSEQ for 64-bit
-// x86, Arm binaries.
+// x86, Arm binaries, but only with GCC >= 11 or Clang >= 11 for Arm.
 #if !defined(TCMALLOC_INTERNAL_PERCPU_USE_RSEQ)
 #if TCMALLOC_PERCPU_RSEQ_SUPPORTED_PLATFORM == 1
 #define TCMALLOC_INTERNAL_PERCPU_USE_RSEQ 1

--- a/tcmalloc/internal/percpu_tcmalloc.h
+++ b/tcmalloc/internal/percpu_tcmalloc.h
@@ -40,6 +40,9 @@
 #if defined(TCMALLOC_INTERNAL_PERCPU_USE_RSEQ)
 #if !defined(__clang__)
 #define TCMALLOC_INTERNAL_PERCPU_USE_RSEQ_ASM_GOTO 1
+#if __GNUC__ >= 11
+#define TCMALLOC_INTERNAL_PERCPU_USE_RSEQ_ASM_GOTO_OUTPUT 1
+#endif
 #elif __clang_major__ >= 9 && !__has_feature(speculative_load_hardening)
 // asm goto requires the use of Clang 9 or newer:
 // https://releases.llvm.org/9.0.0/tools/clang/docs/ReleaseNotes.html#c-language-changes-in-clang


### PR DESCRIPTION
gcc-9, gcc-10, and clang-10 on aarch64 can not compile the current RSEQ inline assembly code.
Add gcc 11 or clang 11 to RSEQ platform support constraints to fix this.

Without this change, GCC 9.4 and 10.3 on aarch64 fail to compile like so:
```
./tcmalloc/internal/percpu_tcmalloc.h:665:9: error: expected ':' or '::' before '[' token
  665 |       : [end_ptr] "=&r"(end_ptr), [cpu_id] "=&r"(cpu_id),
      |         ^
```
Likewise, clang-10 on aarch64 fails to compile like this:
```
./tcmalloc/internal/percpu_tcmalloc.h:665:9: error: 'asm goto' cannot have output constraints
      : [end_ptr] "=&r"(end_ptr), [cpu_id] "=&r"(cpu_id),
        ^
./tcmalloc/internal/percpu_tcmalloc.h:1005:23: error: invalid output constraint '=@ccge' in asm
          [underflow] "=@ccge"(underflow),
                      ^
```
Define `TCMALLOC_INTERNAL_PERCPU_USE_RSEQ_ASM_GOTO_OUTPUT=1` also for GCC,
now that the minimum supported version is set to GCC 11.

Also simplify clang checks now that the minimum supported version for
inline rseq is clang 11.
