### PR TITLE
Fix build with glibc 2.34

### DIFF
--- a/tcmalloc/testing/get_stats_test.cc
+++ b/tcmalloc/testing/get_stats_test.cc
@@ -231,7 +231,7 @@ TEST_F(GetStatsTest, StackDepth) {
   // much stack space gathering statistics.
   //
   // Running out of stack space will manifest as a segmentation fault.
-  constexpr size_t kMaxStackDepth = std::max(60 * 1024, PTHREAD_STACK_MIN);
+  const size_t kMaxStackDepth = std::max<size_t>(60 * 1024, PTHREAD_STACK_MIN);
 
   struct Args {
     bool plaintext;


### PR DESCRIPTION
GNU C Library versions since 2.34 define PTHREAD_STACK_MIN as the result of a function call [ChangeLog](https://lists.gnu.org/archive/html/info-gnu/2021-08/msg00001.html).