### PR TITLE
Update rules_fuzzing

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -104,9 +104,9 @@ rules_proto_toolchains()
 # Fuzzing
 http_archive(
     name = "rules_fuzzing",
-    sha256 = "a5734cb42b1b69395c57e0bbd32ade394d5c3d6afbfe782b24816a96da24660d",
-    strip_prefix = "rules_fuzzing-0.1.1",
-    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.1.zip"],
+    sha256 = "23bb074064c6f488d12044934ab1b0631e8e6898d5cf2f6bde087adb01111573",
+    strip_prefix = "rules_fuzzing-0.3.1",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.3.1.zip"],
 )
 
 # Protobuf


### PR DESCRIPTION
OSS-Fuzz recently failed building tcmalloc fuzzers due to an old version of rules_fuzzing. This fixes it.