### PR TITLE
Restore compatibility with --incompatible_disallow_empty_glob

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,10 @@
 
 build --cxxopt='-std=c++17'
 
+# Flip incompatible_disallow_empty_glob to avoid breaking forward compatibility, see
+# https://github.com/bazelbuild/bazel/pull/15327 for details.
+build --incompatible_disallow_empty_glob
+
 # Define the --config=asan-libfuzzer configuration.
 build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
 build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer

--- a/tcmalloc/BUILD
+++ b/tcmalloc/BUILD
@@ -710,7 +710,6 @@ cc_test(
     name = "span_fuzz",
     srcs = ["span_fuzz.cc"],
     copts = TCMALLOC_DEFAULT_COPTS,
-    data = glob(["testdata/span_fuzz/*"]),
     deps = [
         ":common_8k_pages",
         "//tcmalloc/internal:logging",
@@ -724,7 +723,6 @@ cc_test(
     name = "sizemap_fuzz",
     srcs = ["sizemap_fuzz.cc"],
     copts = TCMALLOC_DEFAULT_COPTS,
-    data = glob(["testdata/sizemap_fuzz/*"]),
     deps = [
         ":common_8k_pages",
         ":size_class_info",
@@ -755,7 +753,6 @@ cc_test(
     name = "transfer_cache_fuzz",
     srcs = ["transfer_cache_fuzz.cc"],
     copts = TCMALLOC_DEFAULT_COPTS,
-    data = glob(["testdata/transfer_cache_fuzz/*"]),
     deps = [
         ":common_8k_pages",
         ":mock_central_freelist",
@@ -1035,7 +1032,6 @@ cc_test(
     name = "malloc_extension_fuzz",
     srcs = ["malloc_extension_fuzz.cc"],
     copts = TCMALLOC_DEFAULT_COPTS,
-    data = glob(["testdata/malloc_extension_fuzz/*"]),
     deps = [
         ":malloc_extension",
         "@com_google_absl//absl/types:optional",

--- a/tcmalloc/internal/BUILD
+++ b/tcmalloc/internal/BUILD
@@ -957,7 +957,6 @@ cc_test(
     name = "sysinfo_fuzz",
     srcs = ["sysinfo_fuzz.cc"],
     copts = TCMALLOC_DEFAULT_COPTS,
-    data = glob(["testdata/sysinfo_fuzz/*"]),
     deps = [
         ":sysinfo",
         "@com_google_fuzztest//fuzztest",


### PR DESCRIPTION
**Background**
Bazel defines a `--incompatible_disallow_empty_glob` flag that is used to disallow glob statements that resolve to an empty set of files. The flag is currently off-by-default, [set to be flipped](https://github.com/bazelbuild/bazel/pull/15327) in a future Bazel version. I work on a project that has already enabled the flag for forward compatibility and uses tcmalloc as a dependency.

**Issue**
Tcmalloc used to work with --incompatible_disallow_empty_glob enabled, but bb80955d added several empty globs, which breaks the build with the flag enabled.
This PR drops the empty globs, restoring compatibility. It also enables the flag in .bazelrc so this won't break again – that part is optional, I'd still be happy if the fix itself gets integrated.