### PR TITLE
fix percpu ODR linker warning

### DIFF
--- a/tcmalloc/internal/percpu.cc
+++ b/tcmalloc/internal/percpu.cc
@@ -42,6 +42,7 @@
 GOOGLE_MALLOC_SECTION_BEGIN
 namespace tcmalloc {
 namespace tcmalloc_internal {
+class Sampler;
 namespace subtle {
 namespace percpu {
 
@@ -62,7 +63,7 @@ ABSL_CONST_INIT static absl::once_flag init_per_cpu_once;
 ABSL_CONST_INIT static std::atomic<bool> using_upstream_fence{false};
 #endif  // TCMALLOC_INTERNAL_PERCPU_USE_RSEQ
 
-extern "C" thread_local char tcmalloc_sampler ABSL_ATTRIBUTE_INITIAL_EXEC;
+extern "C" thread_local Sampler tcmalloc_sampler ABSL_ATTRIBUTE_INITIAL_EXEC;
 
 static bool InitThreadPerCpu() {
   // If we're already registered, there's nothing further for us to do.


### PR DESCRIPTION
The following warning was received:
INFO: From Linking tcmalloc/libtcmalloc.so:
tcmalloc/internal/percpu.cc:65:30: warning: 'tcmalloc_sampler' violates the C++ One Definition Rule [-Wodr] ./tcmalloc/sampler.h:89:7: note: type name 'tcmalloc::tcmalloc_internal::Sampler' should match type name 'char' ./tcmalloc/allocation_sampling.h:57:58: note: 'tcmalloc_sampler' was previously declared here

the commit change is correcting the ODR problem.