### PR TITLE
Support Bazel 8, remove deprecated rules_proto

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,10 +21,10 @@ module(
 
 bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "fuzztest", version = "20241028.0", repo_name = "com_google_fuzztest")
 bazel_dep(name = "google_benchmark", version = "1.8.3", repo_name = "com_github_google_benchmark")
 bazel_dep(name = "googletest", version = "1.13.0", repo_name = "com_google_googletest")
-bazel_dep(name = "protobuf", version = "26.0", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "27.5", repo_name = "com_google_protobuf")
 bazel_dep(name = "re2", version = "2024-02-01", repo_name = "com_googlesource_code_re2")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_fuzzing", version = "0.5.1")
-bazel_dep(name = "rules_proto", version = "4.0.0")
+bazel_dep(name = "rules_fuzzing", version = "0.5.2")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -80,15 +80,16 @@ http_archive(
 # Proto rules for Bazel and Protobuf
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "9ca59193fcfe52c54e4c2b4584770acd1a6528fc35efad363f8513c224490c50",
-    strip_prefix = "protobuf-13d559beb6967033a467a7517c35d8ad970f8afb",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/13d559beb6967033a467a7517c35d8ad970f8afb.zip"],
+    integrity = "sha256-ecxtCdAnBsWnPpAOqEK1s9rhYPNxtmVHdJR/54GFFCM=",
+    strip_prefix = "protobuf-27.5",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v27.5.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
+# rules_proto is deprecated, but still needed by fuzztest.
 http_archive(
     name = "rules_proto",
     sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -12,14 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# See MODULE.bazel for external dependencies setup.
-
-# Having both WORKSPACE and MODULE.bazel specify dependencies is brittle.
-# fuzztest is not yet available via Bazel registry, but should be soon:
-#   https://github.com/bazelbuild/bazel-central-registry/issues/1391
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "com_google_fuzztest",
-    strip_prefix = "fuzztest-7e084905bce6ffa97b58cf8e8945e5cea2348a5a",
-    url = "https://github.com/google/fuzztest/archive/7e084905bce6ffa97b58cf8e8945e5cea2348a5a.zip",
-)
+# https://bazel.build/external/migration#workspace.bzlmod
+#
+# This file is intentionally empty. When bzlmod is enabled and this
+# file exists, the content of WORKSPACE is ignored. This prevents
+# bzlmod builds from unintentionally depending on the WORKSPACE file.

--- a/tcmalloc/BUILD
+++ b/tcmalloc/BUILD
@@ -70,7 +70,6 @@ tcmalloc_deps = [
     "@com_google_absl//absl/base:config",
     "@com_google_absl//absl/base:core_headers",
     "@com_google_absl//absl/base:dynamic_annotations",
-    "@com_google_absl//absl/debugging:leak_check",
     "@com_google_absl//absl/debugging:stacktrace",
     "@com_google_absl//absl/debugging:symbolize",
     "//tcmalloc/selsan",

--- a/tcmalloc/internal/BUILD
+++ b/tcmalloc/internal/BUILD
@@ -14,8 +14,8 @@
 #
 # Internal libraries used for the implementation and testing of TCMalloc.
 
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//tcmalloc:copts.bzl", "TCMALLOC_DEFAULT_COPTS")
 load("//tcmalloc:variants.bzl", "create_tcmalloc_benchmark")
 


### PR DESCRIPTION
Improve dependency management to support Bazel 8 properly, this is now working at least with bzlmod.

- Update rules_fuzzing to fix version compatibility issue with protobuf
- rules_proto is deprecated. Import rules directly from protobuf as is intended with Bazel 8. Update protobuf to 27.5 since 26.0 does not define the required rules.
- Import fuzztest in bzlmod – this way WORKSPACE.bzlmod is now empty.
- Cleanup: remove redundant absl/debugging:leak_check dependency from tcmalloc library