### PR TITLE
Update google_benchmark to avoid rules_foreign_cc dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ module(
 bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "fuzztest", version = "20241028.0", repo_name = "com_google_fuzztest")
-bazel_dep(name = "google_benchmark", version = "1.8.3", repo_name = "com_github_google_benchmark")
+bazel_dep(name = "google_benchmark", version = "1.9.2", repo_name = "com_github_google_benchmark")
 bazel_dep(name = "googletest", version = "1.13.0", repo_name = "com_google_googletest")
 bazel_dep(name = "protobuf", version = "27.5", repo_name = "com_google_protobuf")
 bazel_dep(name = "re2", version = "2024-02-01", repo_name = "com_googlesource_code_re2")


### PR DESCRIPTION
Inspired by https://github.com/bazelbuild/bazel-central-registry/pull/4195#discussion_r2021834384