### PR TITLE
Add cc_static_library for non-bazel projects

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -254,6 +254,21 @@ build --cxxopt='-std=c++17'
 
 Congratulations! You've created your first binary using TCMalloc.
 
+### Using TCMalloc in non-Bazel Projects
+
+If you are not using Bazel, you can instead build a standalone version
+of TCMalloc that you can vendor in your project. Before doing so you
+should still run the tests, as described above, to make sure the
+vendored library will work in your environment. Then build the
+standalone bazel target:
+
+```
+tcmalloc$ bazel build tcmalloc:tcmalloc_standalone --experimental_cc_static_library
+```
+
+Once this builds you can copy the resulting static library from
+`bazel-bin/tcmalloc/libtcmalloc_standalone.a` into your project!
+
 ## What's Next
 
 *   Read our [overview](overview.md), if you haven't already. The overview

--- a/tcmalloc/BUILD
+++ b/tcmalloc/BUILD
@@ -111,6 +111,12 @@ cc_library(
     alwayslink = 1,
 )
 
+cc_static_library(
+    name = "tcmalloc_standalone",
+    deps = [":tcmalloc"],
+    tags = ["manual"],
+)
+
 cc_library(
     name = "tcmalloc_internal_methods_only",
     srcs = [


### PR DESCRIPTION
Bazel 7.4.x+ have a new `cc_static_library` rule that creates a
redistributable static library from a set of deps. This allows us to
create a standalone version of tcmalloc that users can easily pull into
non-bazel projects.

This should lower the friction for cmake users to use tcmalloc.
