### PR TITLE
unbreak compilation with GCC 14

### DIFF
--- a/tcmalloc/static_vars.cc
+++ b/tcmalloc/static_vars.cc
@@ -114,7 +114,7 @@ TCMALLOC_ATTRIBUTE_NO_DESTROY ABSL_CONST_INIT SystemAllocator<
 // section automatically, even though we will never mutate this particular
 // instance.
 ABSL_ATTRIBUTE_SECTION_VARIABLE(.data.rel.ro)
-constexpr Span Static::kInvalidSpan;
+const Span Static::kInvalidSpan = {};
 // LINT.ThenChange(:static_vars_size)
 
 ABSL_CONST_INIT Static tc_globals;

--- a/tcmalloc/static_vars.h
+++ b/tcmalloc/static_vars.h
@@ -256,8 +256,7 @@ class Static final {
       NumaTopology<kNumaPartitions, kNumBaseClasses>, kNormalPartitions>
       system_allocator_;
 
-  static ABSL_ATTRIBUTE_SECTION_VARIABLE(.data.rel.ro) constexpr Span
-      kInvalidSpan{};
+  static const Span kInvalidSpan;
 
   // Manages sampled allocations and allows iteration over samples free from the
   // global pageheap_lock.


### PR DESCRIPTION
With previous code gcc ended up giving odd error about section mismatch for kInvalidSpan. Not sure what it was, but kInvalidSpan is only used for it's address. So there is never need for constexpr it. This change turns it into "classic" constant which is declared in the header and defined in the .cc (with whatever section attribute it needs).