### PR TITLE
Add configurable hugepage optimization for large allocations

### DIFF
--- a/tcmalloc/internal/parameter_accessors.h
+++ b/tcmalloc/internal/parameter_accessors.h
@@ -109,6 +109,8 @@ ABSL_ATTRIBUTE_WEAK void TCMalloc_Internal_SetUseUserspaceCollapseHeuristics(
 ABSL_ATTRIBUTE_WEAK bool TCMalloc_Internal_GetHeapPartitioning();
 ABSL_ATTRIBUTE_WEAK bool TCMalloc_Internal_GetBackSmallAllocations();
 ABSL_ATTRIBUTE_WEAK void TCMalloc_Internal_SetBackSmallAllocations(bool v);
+ABSL_ATTRIBUTE_WEAK bool TCMalloc_Internal_GetMadviseHugepageMmapEnabled();
+ABSL_ATTRIBUTE_WEAK void TCMalloc_Internal_SetMadviseHugepageMmapEnabled(bool v);
 ABSL_ATTRIBUTE_WEAK int32_t TCMalloc_Internal_GetBackSizeThresholdBytes();
 ABSL_ATTRIBUTE_WEAK void TCMalloc_Internal_SetBackSizeThresholdBytes(int32_t v);
 ABSL_ATTRIBUTE_WEAK bool TCMalloc_Internal_GetEnableUnfilteredCollapse();

--- a/tcmalloc/internal/system_allocator.h
+++ b/tcmalloc/internal/system_allocator.h
@@ -377,6 +377,13 @@ SystemAllocator<Topology, NormalPartitions>::MmapRegion::Alloc(
     // This is only advisory, so ignore the error.
     ErrnoRestorer errno_restorer;
     (void)madvise(result_ptr, actual_size, MADV_NOHUGEPAGE);
+  } else if (Parameters::madvise_hugepage_mmap_enabled()) {
+    // Opt-in to transparent hugepages when system is 
+    // configured for transparent_hugepage=madvise. This can improve memory
+    // performance by reducing TLB pressure.
+    // This is only advisory, so ignore the error.
+    ErrnoRestorer errno_restorer;
+    (void)madvise(result_ptr, actual_size, MADV_HUGEPAGE);
   }
   free_size_ -= actual_size;
   return {result_ptr, actual_size};

--- a/tcmalloc/parameters.cc
+++ b/tcmalloc/parameters.cc
@@ -244,6 +244,8 @@ ABSL_CONST_INIT std::atomic<int32_t> Parameters::back_size_threshold_bytes_(
     kPageSize);
 ABSL_CONST_INIT std::atomic<bool> Parameters::enable_unfiltered_collapse_(
     false);
+ABSL_CONST_INIT std::atomic<bool> Parameters::madvise_hugepage_mmap_enabled_(
+    false);
 
 static std::atomic<bool>& back_small_allocations_enabled() {
   ABSL_CONST_INIT static absl::once_flag flag;
@@ -334,6 +336,11 @@ Parameters::span_lifetime_tracking() {
 int32_t Parameters::max_per_cpu_cache_size() {
   return tc_globals.cpu_cache().CacheLimit();
 }
+
+bool TCMalloc_Internal_GetMadviseHugepageMmapEnabled() {
+  return Parameters::madvise_hugepage_mmap_enabled();
+}
+
 
 int ABSL_ATTRIBUTE_WEAK default_want_disable_dynamic_slabs();
 
@@ -640,6 +647,10 @@ bool TCMalloc_Internal_GetBackSmallAllocations() {
 void TCMalloc_Internal_SetBackSmallAllocations(bool v) {
   tcmalloc::tcmalloc_internal::back_small_allocations_enabled().store(
       v, std::memory_order_relaxed);
+}
+
+void TCMalloc_Internal_SetMadviseHugepageMmapEnabled(bool v) {
+  Parameters::madvise_hugepage_mmap_enabled_.store(v, std::memory_order_relaxed);
 }
 
 void TCMalloc_Internal_SetBackSizeThresholdBytes(int32_t v) {

--- a/tcmalloc/parameters.h
+++ b/tcmalloc/parameters.h
@@ -185,6 +185,10 @@ class Parameters {
     TCMalloc_Internal_SetPerCpuCachesDynamicSlabShrinkThreshold(value);
   }
 
+  static bool madvise_hugepage_mmap_enabled() {
+    return madvise_hugepage_mmap_enabled_.load(std::memory_order_relaxed);
+  }
+
   static bool heap_partitioning();
 
   static central_freelist_internal::LifetimeTracking span_lifetime_tracking();
@@ -224,6 +228,7 @@ class Parameters {
   friend void ::TCMalloc_Internal_SetBackSmallAllocations(bool v);
   friend void ::TCMalloc_Internal_SetBackSizeThresholdBytes(int32_t v);
   friend void ::TCMalloc_Internal_SetEnableUnfilteredCollapse(bool v);
+  friend void ::TCMalloc_Internal_SetMadviseHugepageMmapEnabled(bool v);
 
   static std::atomic<int64_t> guarded_sampling_interval_;
   static std::atomic<int32_t> max_per_cpu_cache_size_;
@@ -243,6 +248,7 @@ class Parameters {
   static std::atomic<bool> use_userspace_collapse_heuristics_;
   static std::atomic<int32_t> back_size_threshold_bytes_;
   static std::atomic<bool> enable_unfiltered_collapse_;
+  static std::atomic<bool> madvise_hugepage_mmap_enabled_;
 };
 
 }  // namespace tcmalloc_internal


### PR DESCRIPTION
## Summary
Adds proactive hugepage optimization to improve memory performance for allocations ≥2MB while preserving existing memory management behavior.

## Changes
- Modified `MmapRegion::Alloc()` in `system_allocator.h` to apply `MADV_HUGEPAGE` for large allocations
- No sized gate, parameters-based control, default off
- Preserves existing `MADV_NOHUGEPAGE` logic for infrequent access patterns
