### PR TITLE
Fix off-by-one in stacktrace filter probability when pool is empty.

### DIFF
--- a/tcmalloc/guarded_page_allocator.cc
+++ b/tcmalloc/guarded_page_allocator.cc
@@ -146,7 +146,7 @@ GuardedAllocWithStatus GuardedPageAllocator::TrySample(
       // proportional to pool utilization, with pool utilization of 50% or more
       // resulting in always filtering currently covered allocations.
       const size_t usage_pct = (allocated_pages() * 100) / max_allocated_pages_;
-      if (rand_.Next() % 50 <= usage_pct) {
+      if (rand_.Next() % 50 < usage_pct) {
         // Decay even if the current allocation is filtered, so that we keep
         // sampling even if we only see the same allocations over and over.
         stacktrace_filter_.Decay();

--- a/tcmalloc/guarded_page_allocator.cc
+++ b/tcmalloc/guarded_page_allocator.cc
@@ -143,7 +143,7 @@ GuardedAllocWithStatus GuardedPageAllocator::TrySample(
 
     if (stacktrace_filter_.Contains({stack_trace.stack, stack_trace.depth})) {
       // The probability that we skip a currently covered allocation scales
-      // proportional to pool utilization, with pool utilization of 50% or more
+      // proportional to pool utilization, with pool utilization greater than 50%
       // resulting in always filtering currently covered allocations.
       const size_t usage_pct = (allocated_pages() * 100) / max_allocated_pages_;
       if (rand_.Next() % 50 < usage_pct) {


### PR DESCRIPTION
When usage_pct == 0 (pool utilization 0%), the condition 'rand_.Next() % 50 <= usage_pct' incorrectly filtered allocations with probability 1/50 = 2%, because rand % 50 == 0 satisfies <= 0.

Change to '<' so that usage_pct == 0 yields 0% filter probability, matching the intended behavior: filter probability scales with pool utilization, and 0% utilization should never filter.