### PR TITLE
Build tcmalloc as a shared library

### DIFF
--- a/tcmalloc/BUILD
+++ b/tcmalloc/BUILD
@@ -1654,6 +1654,13 @@ cc_library(
     deps = ["@com_google_absl//absl/base:core_headers"],
 )
 
+cc_binary(
+    name = "libtcmalloc.so",
+    deps = [":tcmalloc"],
+    linkshared = 1,
+    copts = TCMALLOC_DEFAULT_COPTS,
+)
+
 # Expose internals to privileged external repositories.
 package_group(
     name = "friends",


### PR DESCRIPTION
Build command to generate libtcmalloc.so:
bazel build //tcmalloc:libtcmalloc.so