### PR TITLE
Record NUMA nodes >= 32 in the partition node bitmap

### DIFF
--- a/tcmalloc/internal/numa.cc
+++ b/tcmalloc/internal/numa.cc
@@ -126,7 +126,7 @@ bool InitNumaTopology(size_t cpu_to_scaled_partition[kMaxCpus],
 
     // Record this node in partition_to_nodes.
     const size_t partition = NodeToPartition(node, num_partitions);
-    partition_to_nodes[partition] |= 1 << node;
+    partition_to_nodes[partition] |= uint64_t{1} << node;
 
     // cpu_to_scaled_partition_ entries are default initialized to zero, so
     // skip redundantly parsing CPU lists for nodes that map to partition 0.

--- a/tcmalloc/internal/numa_test.cc
+++ b/tcmalloc/internal/numa_test.cc
@@ -233,6 +233,24 @@ TEST_F(NumaTopologyTest, LongCpuLists) {
   }
 }
 
+// Ensure that NUMA nodes with an index >= 32 are recorded in the partition
+// bitmap.  partition_to_nodes is a uint64_t bitmap, so the node index must be
+// shifted in a 64-bit type; shifting a 32-bit int by >= 31 would be undefined
+// behavior and would drop (or corrupt) the bit for such nodes.
+TEST_F(NumaTopologyTest, HighNodeIndex) {
+  // 33 nodes (indices 0..32).  Node 32 maps to partition 0 (32 % 4 == 0) and
+  // must set bit 32 of the partition 0 node bitmap.
+  std::vector<SyntheticCpuList> nodes;
+  for (size_t node = 0; node < 33; ++node) {
+    nodes.emplace_back(absl::StrCat(node));
+  }
+
+  const auto nt = CreateNumaTopology<4>(nodes);
+
+  EXPECT_EQ(nt.numa_aware(), true);
+  EXPECT_EQ(nt.GetPartitionNodes(0) & (uint64_t{1} << 32), uint64_t{1} << 32);
+}
+
 // Ensure we can initialize using the host system's real NUMA topology
 // information.
 TEST_F(NumaTopologyTest, Host) {


### PR DESCRIPTION
## Summary

`InitNumaTopology` (tcmalloc/internal/numa.cc) records each detected NUMA node in the per-partition `partition_to_nodes` bitmap with:

```cpp
partition_to_nodes[partition] |= 1 << node;
```

`node` is a `size_t`, but the literal `1` is a 32-bit signed `int`, so for `node >= 31` the shift is undefined behavior. On x86 (and every supported LP64 Linux ABI, where `int` is 32-bit) the practical result is a corrupted bitmap:

- `node == 31`: `1 << 31` produces a negative `int` that sign-extends to `0xffffffff80000000`, spuriously setting bits 31..63 of the node bitmap.
- `node >= 32`: the shift count is masked modulo 32 (e.g. `1 << 32` == `1 << 0`), setting a lower node's bit instead of the intended one.

This bitmap is consumed by `SystemAllocator::BindMemory` (tcmalloc/internal/system_allocator.h) and passed to `mbind(2)` as the nodemask for NUMA memory binding. On machines with 32 or more NUMA nodes (8-socket EPYC, IBM POWER, etc.) memory can therefore be bound to the wrong nodes — or `mbind` fails with `EINVAL`, which is fatal under `TCMALLOC_NUMA_AWARE=strict-binding`.

## Fix

Shift in a 64-bit type so the intended bit is set:

```cpp
partition_to_nodes[partition] |= uint64_t{1} << node;
```

Behavior is unchanged for `node < 31`.

## Test

Added `NumaTopologyTest.HighNodeIndex`, which initializes a topology with 33 synthetic NUMA nodes (node indices 0..32) and asserts that node 32 is recorded in the partition 0 bitmap. Before this change the test fails: `1 << 32` evaluates to `1` on x86, so bit 32 is never set; after the change it passes.

## Verification

- Reproduced the corruption with a standalone C++ simulation on x86: for `node` in {31, 32, 33, 63}, the old expression set `0xffffffff80000000`, `0x1`, `0x2`, and `0xffffffff80000000` respectively, while the fixed expression sets exactly the intended single bit.
- `partition_to_nodes` is declared as `uint64_t partition_to_nodes_[kNumInternalPartitions]` in numa.h; `uint64_t{1}` matches the shift style already used elsewhere in the tree (e.g. tcmalloc/internal/pageflags.cc).