### PR TITLE
fix(libc_override): define TCMALLOC_NOTHROW unconditionally as noexcept (fixes #150)

### DIFF
--- a/tcmalloc/libc_override.h
+++ b/tcmalloc/libc_override.h
@@ -39,11 +39,11 @@
 #define TCMALLOC_ALIAS(tc_fn) \
   __attribute__((alias(#tc_fn), visibility("default")))
 
+#define TCMALLOC_NOTHROW noexcept
+
 // NOLINTBEGIN(misc-definitions-in-headers)
 
 #if defined(__GLIBC__)
-
-#define TCMALLOC_NOTHROW noexcept
 
 extern "C" {
 
@@ -110,11 +110,6 @@ void* (*__MALLOC_HOOK_VOLATILE __memalign_hook)(size_t, size_t, const void*) =
     &glibc_override_memalign;
 
 }  // extern "C"
-
-#else
-
-#define TCMALLOC_NOTHROW
-
 #endif  // defined(__GLIBC__)
 
 void* operator new(size_t size) noexcept(false)

--- a/tcmalloc/libc_override.h
+++ b/tcmalloc/libc_override.h
@@ -39,31 +39,29 @@
 #define TCMALLOC_ALIAS(tc_fn) \
   __attribute__((alias(#tc_fn), visibility("default")))
 
-#define TCMALLOC_NOTHROW noexcept
-
 // NOLINTBEGIN(misc-definitions-in-headers)
 
 #if defined(__GLIBC__)
 
 extern "C" {
 
-void* __libc_malloc(size_t size) TCMALLOC_NOTHROW
+void* __libc_malloc(size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMalloc);
-void __libc_free(void* ptr) TCMALLOC_NOTHROW
+void __libc_free(void* ptr) noexcept
     TCMALLOC_ALIAS(TCMallocInternalFree);
-void* __libc_realloc(void* ptr, size_t size) TCMALLOC_NOTHROW
+void* __libc_realloc(void* ptr, size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalRealloc);
-void* __libc_calloc(size_t n, size_t size) TCMALLOC_NOTHROW
+void* __libc_calloc(size_t n, size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalCalloc);
-void __libc_cfree(void* ptr) TCMALLOC_NOTHROW
+void __libc_cfree(void* ptr) noexcept
     TCMALLOC_ALIAS(TCMallocInternalCfree);
-void* __libc_memalign(size_t align, size_t s) TCMALLOC_NOTHROW
+void* __libc_memalign(size_t align, size_t s) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMemalign);
-void* __libc_valloc(size_t size) TCMALLOC_NOTHROW
+void* __libc_valloc(size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalValloc);
-void* __libc_pvalloc(size_t size) TCMALLOC_NOTHROW
+void* __libc_pvalloc(size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalPvalloc);
-int __posix_memalign(void** r, size_t a, size_t s) TCMALLOC_NOTHROW
+int __posix_memalign(void** r, size_t a, size_t s) noexcept
     TCMALLOC_ALIAS(TCMallocInternalPosixMemalign);
 
 // We also have to hook libc malloc.  While our work with weak symbols
@@ -160,57 +158,57 @@ void operator delete[](void* p, size_t size,
 
 extern "C" {
 
-void* malloc(size_t size) TCMALLOC_NOTHROW
+void* malloc(size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMalloc);
-void free(void* ptr) TCMALLOC_NOTHROW TCMALLOC_ALIAS(TCMallocInternalFree);
-void free_sized(void* ptr, size_t size) TCMALLOC_NOTHROW
+void free(void* ptr) noexcept TCMALLOC_ALIAS(TCMallocInternalFree);
+void free_sized(void* ptr, size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalFreeSized);
-void free_aligned_sized(void* ptr, size_t align, size_t size) TCMALLOC_NOTHROW
+void free_aligned_sized(void* ptr, size_t align, size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalFreeAlignedSized);
 void sdallocx(void* ptr, size_t size, int flags) noexcept
     TCMALLOC_ALIAS(TCMallocInternalSdallocx);
-void* realloc(void* ptr, size_t size) TCMALLOC_NOTHROW
+void* realloc(void* ptr, size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalRealloc);
-void* reallocarray(void* ptr, size_t n, size_t size) TCMALLOC_NOTHROW
+void* reallocarray(void* ptr, size_t n, size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalReallocArray);
-void* calloc(size_t n, size_t size) TCMALLOC_NOTHROW
+void* calloc(size_t n, size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalCalloc);
-void cfree(void* ptr) TCMALLOC_NOTHROW TCMALLOC_ALIAS(TCMallocInternalCfree);
-void* memalign(size_t align, size_t s) TCMALLOC_NOTHROW
+void cfree(void* ptr) noexcept TCMALLOC_ALIAS(TCMallocInternalCfree);
+void* memalign(size_t align, size_t s) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMemalign);
-void* aligned_alloc(size_t align, size_t s) TCMALLOC_NOTHROW
+void* aligned_alloc(size_t align, size_t s) noexcept
     TCMALLOC_ALIAS(TCMallocInternalAlignedAlloc);
-void* valloc(size_t size) TCMALLOC_NOTHROW
+void* valloc(size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalValloc);
-void* pvalloc(size_t size) TCMALLOC_NOTHROW
+void* pvalloc(size_t size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalPvalloc);
-int posix_memalign(void** r, size_t a, size_t s) TCMALLOC_NOTHROW
+int posix_memalign(void** r, size_t a, size_t s) noexcept
     TCMALLOC_ALIAS(TCMallocInternalPosixMemalign);
-void malloc_stats(void) TCMALLOC_NOTHROW
+void malloc_stats(void) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMallocStats);
-int malloc_trim(size_t pad) TCMALLOC_NOTHROW
+int malloc_trim(size_t pad) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMallocTrim);
-int mallopt(int cmd, int value) TCMALLOC_NOTHROW
+int mallopt(int cmd, int value) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMallOpt);
 #ifdef TCMALLOC_HAVE_STRUCT_MALLINFO
-struct mallinfo mallinfo(void) TCMALLOC_NOTHROW
+struct mallinfo mallinfo(void) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMallInfo);
 #endif
 #ifdef TCMALLOC_HAVE_STRUCT_MALLINFO2
-struct mallinfo2 mallinfo2(void) TCMALLOC_NOTHROW
+struct mallinfo2 mallinfo2(void) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMallInfo2);
 #endif
-int malloc_info(int opts, FILE* fp) TCMALLOC_NOTHROW
+int malloc_info(int opts, FILE* fp) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMallocInfo);
-size_t malloc_size(void* p) TCMALLOC_NOTHROW
+size_t malloc_size(void* p) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMallocSize);
-size_t malloc_usable_size(void* p) TCMALLOC_NOTHROW
+size_t malloc_usable_size(void* p) noexcept
     TCMALLOC_ALIAS(TCMallocInternalMallocSize);
 
-alloc_result_t alloc_at_least(size_t min_size) TCMALLOC_NOTHROW
+alloc_result_t alloc_at_least(size_t min_size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalAllocAtLeast);
 alloc_result_t aligned_alloc_at_least(size_t alignment,
-                                      size_t min_size) TCMALLOC_NOTHROW
+                                      size_t min_size) noexcept
     TCMALLOC_ALIAS(TCMallocInternalAlignedAllocAtLeast);
 }  // extern "C"
 

--- a/tcmalloc/malloc_extension.cc
+++ b/tcmalloc/malloc_extension.cc
@@ -750,12 +750,12 @@ ABSL_ATTRIBUTE_WEAK ABSL_ATTRIBUTE_NOINLINE void sdallocx(void* ptr, size_t,
 }
 
 ABSL_ATTRIBUTE_WEAK ABSL_ATTRIBUTE_NOINLINE void free_sized(void* ptr, size_t)
-    TCMALLOC_FREE_SIZED_NOEXCEPT {
+    noexcept {
   free(ptr);
 }
 
 ABSL_ATTRIBUTE_WEAK ABSL_ATTRIBUTE_NOINLINE void free_aligned_sized(
-    void* ptr, size_t, size_t) TCMALLOC_FREE_SIZED_NOEXCEPT {
+    void* ptr, size_t, size_t) noexcept {
   free(ptr);
 }
 

--- a/tcmalloc/malloc_extension.h
+++ b/tcmalloc/malloc_extension.h
@@ -738,21 +738,14 @@ extern "C" [[nodiscard]] size_t nallocx(size_t size, int flags) noexcept;
 extern "C" void sdallocx(void* absl_nullable ptr, size_t size,
                          int flags) noexcept;
 
-#if defined(__GLIBC__) || defined(__Fuchsia__)
-#define TCMALLOC_FREE_SIZED_NOEXCEPT noexcept
-#else
-#define TCMALLOC_FREE_SIZED_NOEXCEPT
-#endif
-
 #if !defined(__STDC_VERSION_STDLIB_H__) || __STDC_VERSION_STDLIB_H__ < 202311L
 // Frees ptr allocated with malloc(size) introduced in C23.
-extern "C" void free_sized(void* absl_nullable ptr,
-                           size_t size) TCMALLOC_FREE_SIZED_NOEXCEPT;
+extern "C" void free_sized(void* absl_nullable ptr, size_t size) noexcept;
 
 // Frees ptr allocated with aligned_alloc/posix_memalign with the specified size
 // and alignment introduced in C23.
 extern "C" void free_aligned_sized(void* absl_nullable ptr, size_t alignment,
-                                   size_t size) TCMALLOC_FREE_SIZED_NOEXCEPT;
+                                   size_t size) noexcept;
 #endif
 
 // Define __sized_ptr_t in the global namespace so that it can be named by the


### PR DESCRIPTION
### Problem Description

Fixes #150

On non-glibc platforms (such as Alpine Linux with musl libc), `__GLIBC__` is not defined. In `tcmalloc/libc_override.h`, `TCMALLOC_NOTHROW` was defined as `noexcept` inside `#if defined(__GLIBC__)`, but left empty (`#define TCMALLOC_NOTHROW`) in the `#else` branch.

As a result, function declarations such as `malloc_size`, `malloc_usable_size`, `malloc`, `free`, `realloc`, etc., were declared without `noexcept`, while their aliased targets (e.g. `TCMallocInternalMallocSize`, `TCMallocInternalMalloc`) are declared with `noexcept` in `tcmalloc/tcmalloc.h`.

When compiling with GCC on musl, this triggers `-Werror=missing-attributes`:
```
error: 'size_t malloc_usable_size(void*)' specifies less restrictive attribute than its target 'size_t TCMallocInternalMallocSize(void*)': 'nothrow' [-Werror=missing-attributes]
```

### Solution

Define `TCMALLOC_NOTHROW` as `noexcept` unconditionally in `tcmalloc/libc_override.h` so that aliases on non-glibc platforms match the `noexcept` specification of their corresponding `TCMallocInternal*` target declarations.
